### PR TITLE
fix: trim whitespaces from env name

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -66,6 +66,7 @@ function main(env = true, dir = null, encoding = null, defaultEnvFallback = true
         var defaultEnvRegex = "\.env$"
         var envRegex = defaultEnvRegex
 
+        if (typeof envname === 'string') envname = envname.trim()
 
         var dirIsDirectory = fs.lstatSync(dir).isDirectory()
 


### PR DESCRIPTION
closes #13